### PR TITLE
Fix sed invalid comment code

### DIFF
--- a/components/iota_cclient/gen_hash_container.sh
+++ b/components/iota_cclient/gen_hash_container.sh
@@ -13,7 +13,7 @@ for HASH_TYPE in ${TYPE_LIST[@]}; do
             if [[ "$OSTYPE" == "darwin" ]]; then
                 sed -i.bak "s/{SIZE}/${HASH_SIZE}/g" ${HASH_TEMPLATE_DIR}/${HASH_FILE_NAME}
             else
-                sed -i "s/{SIZE}/${HASH_SIZE}/g" ${HASH_TEMPLATE_DIR}/${HASH_FILE_NAME}
+                sed -i "" "s/{SIZE}/${HASH_SIZE}/g" ${HASH_TEMPLATE_DIR}/${HASH_FILE_NAME}
             fi
         done
     done


### PR DESCRIPTION
If you are using macOS for development, when using the ‘-i’ flag, you need to provide a blank suffix.